### PR TITLE
Adds Search endpoint to FoldersApi

### DIFF
--- a/src/api/FoldersApi.js
+++ b/src/api/FoldersApi.js
@@ -395,6 +395,62 @@ module.exports = (function() {
         contentTypes, accepts, returnType, oauth2client, credentials
       );
     };
+
+    /**
+     * Searches a folder and sub-folders recursively based on the filters
+     * @param {String} projectId the &#x60;project id&#x60;
+     * @param {String} folderId the &#x60;folder id&#x60;
+     * @param {Array.<String>} filters
+     * @param {Number} pageNumber which page to return
+     * @param {Number} pageLimit maximum number of elements per page
+     * @param {Object} oauth2client oauth2client for the call
+     * @param {Object} credentials credentials for the call
+     */
+    this.search = function(projectId, folderId, filters, pageNumber, pageLimit, oauth2client, credentials) {
+      filters = filters || {};
+      var postBody = null;
+
+      // verify the required parameter 'projectId' is set
+      if (projectId == undefined || projectId == null) {
+        return Promise.reject("Missing the required parameter 'projectId' when calling getFolderContents");
+      }
+
+      // verify the required parameter 'folderId' is set
+      if (folderId == undefined || folderId == null) {
+        return Promise.reject("Missing the required parameter 'folderId' when calling getFolderContents");
+      }
+
+      var pathParams = {
+        'project_id': projectId,
+        'folder_id': folderId
+      };
+
+      var queryParams = {
+        'page[number]': pageNumber,
+        'page[limit]': pageLimit
+      };
+
+      for(var key in filters) {
+        if(filters.hasOwnProperty(key))  {
+          queryParams['filter[' + key + ']'] = filters[key];
+        }
+      }
+
+      var headerParams = {
+      };
+      var formParams = {
+      };
+
+      var contentTypes = ['application/vnd.api+json'];
+      var accepts = ['application/vnd.api+json', 'application/json'];
+      var returnType = JsonApiCollection;
+
+      return this.apiClient.callApi(
+        '/data/v1/projects/{project_id}/folders/{folder_id}/search', 'GET',
+        pathParams, queryParams, headerParams, formParams, postBody,
+        contentTypes, accepts, returnType, oauth2client, credentials
+      );
+    };
   };
 
   return exports;

--- a/test/api/FoldersApi.spec.js
+++ b/test/api/FoldersApi.spec.js
@@ -295,6 +295,52 @@ module.export = (function() {
         });
       });
     });
+
+    describe('search', function() {
+      it('should call search successfully', function(done) {
+        var filters = {
+          type: sampleStrParam,
+          id: sampleStrParam,
+          createTime: sampleStrParam,
+          mimeType: sampleStrParam
+        };
+        var pageNumber = sampleIntParam;
+        var pageLimit = sampleIntParam;
+        var postBody = null;
+
+        var pathParams = {
+          'project_id': sampleStrParam,
+          'folder_id': sampleStrParam
+        };
+        var queryParams = {
+          'filter[type]': filters['type'],
+          'filter[id]': filters['id'],
+          'filter[createTime]': filters['createTime'],
+          'filter[mimeType]': filters['mimeType'],
+          'page[number]': pageNumber,
+          'page[limit]': pageLimit
+        };
+        var headerParams = {
+        };
+        var formParams = {
+        };
+
+        var contentTypes = ['application/vnd.api+json'];
+        var accepts = ['application/vnd.api+json', 'application/json'];
+        var returnType = JsonApiCollection;
+
+        mockedApiClientRequest.withArgs('/data/v1/projects/{project_id}/folders/{folder_id}/search', 'GET',
+                pathParams, queryParams, headerParams, formParams, postBody,
+                contentTypes, accepts, returnType, oauth2client, credentials).returns(Promise.resolve('Success result'));
+
+        instance.search(sampleStrParam, sampleStrParam, filters, pageNumber, pageLimit, oauth2client, credentials).then(function(response){
+            expect(response).to.be.ok();
+            done();
+        }, function(err){
+            done(err);
+        });
+      });
+    });
   });
 
 }());


### PR DESCRIPTION
The documentation describes `page[number]` but not `page[limit]` like it is in the contents endpoint. So I've added it assuming it's a documentation error.

I've added to the FoldersApi spec a similar test as others.

Still needing to test this in a project to ensure it works end to end, but I wanted to get the code in for review.