### PR TITLE
Updated to support application/vnd.api+json

### DIFF
--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -344,7 +344,7 @@ module.exports = (function() {
       requestParams.formData = this.normalizeParams(formParams);
     } else if (bodyParam) {
       requestParams.body = bodyParam;
-      if (contentType == 'application/json'){
+      if (contentType == 'application/json' || contentType == 'application/vnd.api+json'){
         requestParams.json = true;
       }
     }

--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -344,7 +344,7 @@ module.exports = (function() {
       requestParams.formData = this.normalizeParams(formParams);
     } else if (bodyParam) {
       requestParams.body = bodyParam;
-      if (contentType == 'application/json' || contentType == 'application/vnd.api+json'){
+      if (this.isJsonMime(contentType)){
         requestParams.json = true;
       }
     }

--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -115,7 +115,7 @@ module.exports = (function() {
    * @returns {Boolean} <code>true</code> if <code>contentType</code> represents JSON, otherwise <code>false</code>.
    */
   exports.prototype.isJsonMime = function(contentType) {
-    return Boolean(contentType != null && contentType.match(/^application\/json(;.*)?$/i));
+    return Boolean(contentType != null && contentType.match(/^application\/(vnd.api\+)?json(;.*)?$/i));
   };
 
   /**


### PR DESCRIPTION
projects postStorage, and potentially other end points that require the content type to be application/vnd.api+json were failing without this.

The only necessary change is the requestparams.json = true check fix. The other is more optional and I can submit PRs without it if needed.