### PR TITLE
Added optional scope parameter for refreshToken method.

### DIFF
--- a/src/auth/OAuth2ThreeLegged.js
+++ b/src/auth/OAuth2ThreeLegged.js
@@ -134,9 +134,10 @@ module.exports = (function () {
     /**
      * Refresh a 3-legged token
      * @param credentials
+     * @param scope - optional scope for new token. It must be subset of the scopes used for original token.
      * @return Promise
      */
-    OAuth2ThreeLegged.prototype.refreshToken = function (credentials){
+    OAuth2ThreeLegged.prototype.refreshToken = function (credentials, scope) {
         var _this = this;
         return new Promise(function(resolve, reject) {
             if (_this.authentication && _this.authentication.refreshTokenUrl) {
@@ -150,6 +151,9 @@ module.exports = (function () {
                         refresh_token: credentials.refresh_token
                     };
 
+                    if (scope) {
+                        body.scope = scope.join(' ');
+                    }
                     _this.doPostRequest(url, body, function(response){
                         if (response.access_token) {
                             var credentials = Object.assign({}, response,


### PR DESCRIPTION
The purpose is to be able to create token with lower scope using 3L authentication - i.e. for viewing only.