### PR TITLE
Fixed #32 issues with error handling

### DIFF
--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -387,7 +387,7 @@ module.exports = (function() {
                     statusCode: response.statusCode,
                     statusMessage: response.statusMessage
                   });
-                  reject({statusCode: response.statusCode, statusMessage: response.statusMessage});
+                  reject({statusCode: response.statusCode, statusMessage: response.statusMessage, statusBody: body});
                 } else {
                   resolve({statusCode: response.statusCode, headers: response.headers, body: resp});
                 }


### PR DESCRIPTION
Was having a lot of confusion with this issue myself until I notice that the error reason resides in the body instead of in the response itself.  I've added `statusBody` into the error object itself which allow me to get detailed message on what went wrong. 

changes are on line 390 in ApiClient.js
```
   if (response.statusCode >= 400) {
                  _this.debug('error response', {
                    statusCode: response.statusCode,
                    statusMessage: response.statusMessage
                  });
                  reject({statusCode: response.statusCode, statusMessage: response.statusMessage, statusBody: body});
                }
```

(PS: my first pull request, sorry in advance if there's any mistake)