### PR TITLE
forceget qs

### DIFF
--- a/src/api/DerivativesApi.js
+++ b/src/api/DerivativesApi.js
@@ -339,6 +339,7 @@ module.exports = (function() {
         'guid': guid
       };
       var queryParams = {
+        'forceget': opts['forceget'] || false
       };
       var headerParams = {
         'Accept-Encoding': opts['acceptEncoding']


### PR DESCRIPTION
new query string parameter on [GET Properties](https://forge.autodesk.com/en/docs/model-derivative/v2/reference/http/urn-metadata-guid-properties-GET/)

current call:
`derivativesApi.getModelviewProperties(urn, guid, {}, oauthClient, token)`

with this PR:
`derivativesApi.getModelviewProperties(urn, guid, {'forceget': true}, oauthClient, token)`

no breaking change 😄 