### PR TITLE
Fix: Typo error opt

### DIFF
--- a/src/api/ItemsApi.js
+++ b/src/api/ItemsApi.js
@@ -516,7 +516,7 @@ module.exports = (function() {
      * @param {Object} credentials credentials for the call
      */
     this.postItem2 = function(projectId, body, opts, oauth2client, credentials) {
-      opt = opts || {};
+      opts = opts || {};
       var postBody = body;
 
       // verify the required parameter 'projectId' is set


### PR DESCRIPTION
When you try to use postItem it throws an error for the opt variable in the function postItem2.
I just change the variable name from opt to opts