### PR TITLE
Add query parameter to get guid thumbnails

### DIFF
--- a/src/api/DerivativesApi.js
+++ b/src/api/DerivativesApi.js
@@ -169,6 +169,7 @@ module.exports = (function () {
 		 * Returns the thumbnail for the source file.
 		 * @param {String} urn The Base64 (URL Safe) encoded design URN
 		 * @param {Object} opts Optional parameters
+         * @param {String} opts.guid Unique model view ID. Call [GET {urn}/metadata](https://developer.autodesk.com/en/docs/model-derivative/v2/reference/http/urn-metadata-GET) to get the ID
 		 * @param {Integer} opts.width The desired width of the thumbnail. Possible values are 100, 200 and 400.
 		 * @param {Integer} opts.height The desired height of the thumbnail. Possible values are 100, 200 and 400.
 		 * data is of type: {Object}
@@ -189,7 +190,8 @@ module.exports = (function () {
 			};
 			var queryParams = {
 				'width': opts.width,
-				'height': opts.height
+                'height': opts.height,
+                'guid' : opts.guid
 			};
 			var headerParams = {};
 			var formParams = {};

--- a/src/api/DerivativesApi.js
+++ b/src/api/DerivativesApi.js
@@ -191,7 +191,7 @@ module.exports = (function () {
 			var queryParams = {
 				'width': opts.width,
                 'height': opts.height,
-                'guid' : opts.guid
+                'guid': opts.guid
 			};
 			var headerParams = {};
 			var formParams = {};


### PR DESCRIPTION
The only way I found to get **thumbnails** for a specific **guid** is to add the **guid** in the **thumbnail** query :

`https://developer.api.autodesk.com/modelderivative/v2/designdata/{urn}/thumbnail?guid={guid}`

This query parameter is not documented (only width and height) but it is working and I don't know another way to get these specific thumbnails for each **guid**.

I made a quick fix to add this to the `forge-apis`. 