### PR TITLE
fix getObject, adding buffering to properly populate response.body

### DIFF
--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -391,6 +391,7 @@ module.exports = (function () {
 					.set(requestParams.headers)
 					.send(requestParams.body)
 					.query(requestParams.qs || {})
+					.buffer(true)
 					.then((response) => {
 						if (response.statusCode >= 400) {
 							_this.debug('error response', {


### PR DESCRIPTION
after switching from `request` to `superagent` in 0.9.0 release getObject stopped working, the response.body is empty (`{}`), no any errors.
Most likely it affects only objects larger than a certain size (our models are usually bigger than 500K). 
Anyway, the solution is to buffer the response. Please review and accept.