### PR TITLE
fix: add support for `data:read:<URN_OF_RESOURCE>` scopes

### DIFF
--- a/src/auth/OAuth2ThreeLegged.js
+++ b/src/auth/OAuth2ThreeLegged.js
@@ -61,6 +61,13 @@ module.exports = (function () {
 			}
 		};
 
+		for (const key in scope) {
+			const match = scope[key].match(/^data:read:(urn:adsk\.[^*\\"]+)$/);
+			if (match !== null) {
+				this.authentication.scopes[scope[key]] = `The application will have read access to the resource with URN '${match[1]}'.`;
+			}
+		}
+
 		this.authName = 'oauth2_access_code';
 		OAuth2.call(this, clientId, clientSecret, scope, autoRefresh, _ApiClient);
 		this.redirectUri = redirectUri;

--- a/src/auth/OAuth2TwoLegged-v2.js
+++ b/src/auth/OAuth2TwoLegged-v2.js
@@ -59,6 +59,14 @@ module.exports = (function () {
 				'viewables:read': 'The application will have read access to viewable resources such as thumbnails. This scope is a subset of data:read.'
 			}
 		};
+
+		for (const key in scope) {
+			const match = scope[key].match(/^data:read:(urn:adsk\.[^*\\"]+)$/);
+			if (match !== null) {
+				this.authentication.scopes[scope[key]] = `The application will have read access to the resource with URN '${match[1]}'.`;
+			}
+		}
+
 		this.authName = 'oauth2_application';
 		OAuth2.call(this, clientId, clientSecret, scope, autoRefresh, _ApiClient);
 	};

--- a/src/auth/OAuth2TwoLegged.js
+++ b/src/auth/OAuth2TwoLegged.js
@@ -59,6 +59,13 @@ module.exports = (function () {
 			}
 		};
 
+		for (const key in scope) {
+			const match = scope[key].match(/^data:read:(urn:adsk\.[^*\\"]+)$/);
+			if (match !== null) {
+				this.authentication.scopes[scope[key]] = `The application will have read access to the resource with URN '${match[1]}'.`;
+			}
+		}
+
 		this.authName = 'oauth2_application';
 
 		OAuth2.call(this, clientId, clientSecret, scope, autoRefresh, _ApiClient);


### PR DESCRIPTION
Added support for `data:read:<URN_OF_RESOURCE>` dynamic scopes, according to the description on the [docs](https://aps.autodesk.com/en/docs/oauth/v2/developers_guide/scopes/#scope-values):

![image](https://user-images.githubusercontent.com/77465520/221234395-599d8d37-f7be-47a2-ad8e-807a4705af48.png)

Fixes: #95 