### PR TITLE
Add support for Fetch Derivative Download URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Forge Node.js SDK [![Build Status](https://travis-ci.org/Autodesk-Forge/forge-api-nodejs-client.svg?branch=master)](https://travis-ci.org/Autodesk-Forge/forge-api-nodejs-client)
 
 *Forge API*:
-[![oAuth2](https://img.shields.io/badge/oAuth2-v1-green.svg)](https://forge.autodesk.com/developer/documentation)
+[![oAuth2](https://img.shields.io/badge/oAuth2-v2-green.svg)](https://forge.autodesk.com/developer/documentation)
 [![Data-Management](https://img.shields.io/badge/Data%20Management-v1-green.svg)](https://forge.autodesk.com/developer/documentation)
 [![OSS](https://img.shields.io/badge/OSS-v2-green.svg)](https://forge.autodesk.com/developer/documentation)
 [![Model-Derivative](https://img.shields.io/badge/Model%20Derivative-v2-green.svg)](https://forge.autodesk.com/developer/documentation)
@@ -192,15 +192,18 @@ Class | Method | HTTP request | Description
 *ForgeSdk.BucketsApi* | [**deleteBucket**](docs/BucketsApi.md#deleteBucket) | **DELETE** /oss/v2/buckets/{bucketKey} |
 *ForgeSdk.BucketsApi* | [**getBucketDetails**](docs/BucketsApi.md#getBucketDetails) | **GET** /oss/v2/buckets/{bucketKey}/details |
 *ForgeSdk.BucketsApi* | [**getBuckets**](docs/BucketsApi.md#getBuckets) | **GET** /oss/v2/buckets |
+*ForgeSdk.DerivativesApi* | [**getFormats**](docs/DerivativesApi.md#getFormats) | **GET** /modelderivative/v2/designdata/formats |
+*ForgeSdk.DerivativesApi* | [**translate**](docs/DerivativesApi.md#translate) | **POST** /modelderivative/v2/designdata/job |
+*ForgeSdk.DerivativesApi* | [**setReferences**](docs/DerivativesApi.md#setReferences) | **POST** /modelderivative/v2/designdata/{urn}/references |
+*ForgeSdk.DerivativesApi* | [**getThumbnail**](docs/DerivativesApi.md#getThumbnail) | **GET** /modelderivative/v2/designdata/{urn}/thumbnail |
+*ForgeSdk.DerivativesApi* | [**getManifest**](docs/DerivativesApi.md#getManifest) | **GET** /modelderivative/v2/designdata/{urn}/manifest |
 *ForgeSdk.DerivativesApi* | [**deleteManifest**](docs/DerivativesApi.md#deleteManifest) | **DELETE** /modelderivative/v2/designdata/{urn}/manifest |
 *ForgeSdk.DerivativesApi* | [**getDerivativeManifest**](docs/DerivativesApi.md#getDerivativeManifest) | **GET** /modelderivative/v2/designdata/{urn}/manifest/{derivativeUrn} |
-*ForgeSdk.DerivativesApi* | [**getFormats**](docs/DerivativesApi.md#getFormats) | **GET** /modelderivative/v2/designdata/formats |
-*ForgeSdk.DerivativesApi* | [**getManifest**](docs/DerivativesApi.md#getManifest) | **GET** /modelderivative/v2/designdata/{urn}/manifest |
+*ForgeSdk.DerivativesApi* | [**getDerivativeManifestInfo**](docs/DerivativesApi.md#getDerivativeManifestInfo) | **HEAD** /modelderivative/v2/designdata/{urn}/manifest/{derivativeUrn} |
+*ForgeSdk.DerivativesApi* | [**getDerivativeDownloadUrl**](docs/DerivativesApi.md#getDerivativeDownloadUrl) | **GET** /modelderivative/v2/designdata/{urn}/manifest/{derivativeUrn}/signedcookies |
 *ForgeSdk.DerivativesApi* | [**getMetadata**](docs/DerivativesApi.md#getMetadata) | **GET** /modelderivative/v2/designdata/{urn}/metadata |
 *ForgeSdk.DerivativesApi* | [**getModelviewMetadata**](docs/DerivativesApi.md#getModelviewMetadata) | **GET** /modelderivative/v2/designdata/{urn}/metadata/{guid} |
 *ForgeSdk.DerivativesApi* | [**getModelviewProperties**](docs/DerivativesApi.md#getModelviewProperties) | **GET** /modelderivative/v2/designdata/{urn}/metadata/{guid}/properties |
-*ForgeSdk.DerivativesApi* | [**getThumbnail**](docs/DerivativesApi.md#getThumbnail) | **GET** /modelderivative/v2/designdata/{urn}/thumbnail |
-*ForgeSdk.DerivativesApi* | [**translate**](docs/DerivativesApi.md#translate) | **POST** /modelderivative/v2/designdata/job |
 *ForgeSdk.FoldersApi* | [**getFolder**](docs/FoldersApi.md#getFolder) | **GET** /data/v1/projects/{project_id}/folders/{folder_id} |
 *ForgeSdk.FoldersApi* | [**getFolderContents**](docs/FoldersApi.md#getFolderContents) | **GET** /data/v1/projects/{project_id}/folders/{folder_id}/contents |
 *ForgeSdk.FoldersApi* | [**getFolderParent**](docs/FoldersApi.md#getFolderParent) | **GET** /data/v1/projects/{project_id}/folders/{folder_id}/parent |

--- a/bump-version
+++ b/bump-version
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-current_version="0.9.6"
+current_version="0.9.7"
 new_version=$1
 if [ "$new_version" == "" ]; then
 	[[ "$current_version" =~ ([0-9]+).+([0-9]+).+([0-9]+)$ ]] && new_version="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$((${BASH_REMATCH[3]} + 1))"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "forge-apis",
-	"version": "0.9.6",
+	"version": "0.9.7",
 	"description": "The Forge Platform contains an expanding collection of web service components that can be used with Autodesk cloud-based products or your own technologies. Take advantage of Autodesk’s expertise in design and engineering.",
 	"license": "Apache-2.0",
 	"main": "src/index.js",
@@ -42,6 +42,7 @@
 		"retry-axios": "^3.0.0"
 	},
 	"devDependencies": {
+		"eslint": "^8.42.0",
 		"expect.js": "^0.3.1",
 		"mocha": "^9.2.1",
 		"nock": "^13.2.4",

--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -375,7 +375,7 @@ module.exports = (function () {
 		}
 		if (headerParams['Accept-Encoding'] === 'gzip, deflate')
 			requestParams.encoding = null;
-		headerParams['User-Agent'] = 'forge-apis/0.9.6 (nodejs)';
+		headerParams['User-Agent'] = 'forge-apis/0.9.7 (nodejs)';
 		_this.debug('request params were', requestParams);
 
 		return new Promise(function (resolve, reject) {
@@ -502,7 +502,7 @@ module.exports = (function () {
 		}
 	};
 
-	exports.version = '0.9.6';
+	exports.version = '0.9.10';
 
 	exports.userAgentHeaders = {
 		'User-Agent': `forge-apis/${exports.version} nodejs api wrappers library`,

--- a/src/api/DerivativesApi.js
+++ b/src/api/DerivativesApi.js
@@ -32,7 +32,7 @@ module.exports = (function () {
 		JobPayload = require('../model/JobPayload'),
 		Manifest = require('../model/Manifest'),
 		Metadata = require('../model/Metadata'),
-		Result = require('../model/Result');
+		Result = require('../model/Result'),
 		DerivativeDownloadUrl = require('../model/DerivativeDownloadUrl');
 
 	/**

--- a/src/api/DerivativesApi.js
+++ b/src/api/DerivativesApi.js
@@ -367,6 +367,55 @@ module.exports = (function () {
 		};
 
 		/**
+		 * Returns a download URL and a set of signed cookies, which lets you securely download the derivative specified by the derivativeUrn URI parameter.  
+		 * The signed cookies have a lifetime of 6 hours.  
+		 * Although you cannot use range headers for this endpoint, you can use range headers for the returned download URL to download the derivative in chunks, in parallel.  
+		 * See: https://aps.autodesk.com/en/docs/model-derivative/v2/reference/http/urn-manifest-derivativeUrn-signedcookies-GET/
+		 * @param {String} urn The Base64 (URL Safe) encoded design URN
+		 * @param {String} derivativeUrn The URL-encoded URN of the derivatives. The URN is retrieved from the GET :urn/manifest endpoint.
+		 * @param {Object} opts Optional parameters
+		 * @param {Integer} opts.minutesExpiration Specifies how many minutes the signed cookies should remain valid. Default value is 360 minutes. The value you specify must be lower than the default value for this parameter. If you specify a value greater than the default value, the Model Derivative service will return an error with an HTTP status code of 400.
+		 * @param {String} opts.responseContentDisposition The value that must be returned with the download URL as the response-content-disposition query string parameter. Must begin with attachment. This value defaults to the default value corresponding to the derivative/file.
+		 * @param {Object} oauth2client oauth2client for the call
+		 * @param {Object} credentials credentials for the call
+		 */
+		this.getDerivativeDownloadUrl = function (urn, derivativeUrn, opts, oauth2client, credentials) {
+			opts = opts || {};
+			var postBody = null;
+
+			// verify the required parameter 'urn' is set
+			if (urn == undefined || urn == null) {
+				return Promise.reject("Missing the required parameter 'urn' when calling getDerivativeDownloadUrl");
+			}
+
+			// verify the required parameter 'derivativeUrn' is set
+			if (derivativeUrn == undefined || derivativeUrn == null) {
+				return Promise.reject("Missing the required parameter 'derivativeUrn' when calling getDerivativeDownloadUrl");
+			}
+
+			var pathParams = {
+				'urn': urn,
+				'derivativeUrn': derivativeUrn
+			};
+			var queryParams = {
+				'minutes-expiration': opts.minutesExpiration,
+				'response-content-disposition': opts.responseContentDisposition
+			};
+			var headerParams = {};
+			var formParams = {};
+
+			var contentTypes = [];
+			var accepts = [];
+			var returnType = null;
+
+			return this.apiClient.callApi(
+				this.regionPaths[this.region] + '/designdata/{urn}/manifest/{derivativeUrn}/signedcookies', 'GET',
+				pathParams, queryParams, headerParams, formParams, postBody,
+				contentTypes, accepts, returnType, oauth2client, credentials
+			);
+		};
+
+		/**
 		 * Returns a list of model view (metadata) IDs for a design model. The metadata ID enables end users to select an object tree and properties for a specific model view.  Although most design apps (e.g., Fusion and Inventor) only allow a single model view (object tree and set of properties), some apps (e.g., Revit) allow users to design models with multiple model views (e.g., HVAC, architecture, perspective).  Note that you can only retrieve metadata from an input file that has been translated into an SVF file.
 		 * @param {String} urn The Base64 (URL Safe) encoded design URN
 		 * @param {Object} opts Optional parameters

--- a/src/api/DerivativesApi.js
+++ b/src/api/DerivativesApi.js
@@ -33,6 +33,7 @@ module.exports = (function () {
 		Manifest = require('../model/Manifest'),
 		Metadata = require('../model/Metadata'),
 		Result = require('../model/Result');
+		DerivativeDownloadUrl = require('../model/DerivativeDownloadUrl');
 
 	/**
 	 * Derivatives service.
@@ -404,9 +405,9 @@ module.exports = (function () {
 			var headerParams = {};
 			var formParams = {};
 
-			var contentTypes = [];
-			var accepts = [];
-			var returnType = null;
+			var contentTypes = ['application/json'];
+			var accepts = ['*/*'];
+			var returnType = DerivativeDownloadUrl;
 
 			return this.apiClient.callApi(
 				this.regionPaths[this.region] + '/designdata/{urn}/manifest/{derivativeUrn}/signedcookies', 'GET',

--- a/src/model/DerivativeDownloadUrl.js
+++ b/src/model/DerivativeDownloadUrl.js
@@ -1,0 +1,123 @@
+/**
+ * Forge SDK
+ * The Forge Platform contains an expanding collection of web service components that can be used with Autodesk cloud-based products or your own technologies. Take advantage of Autodesk’s expertise in design and engineering.
+ *
+ * Contact: forge.help@autodesk.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = (function () {
+  'use strict';
+
+  var ApiClient = require('../ApiClient');
+
+
+
+  /**
+   * The DerivativeDownloadUrl model module.
+   * @module model/DerivativeDownloadUrl
+   */
+
+  /**
+   * Constructs a <code>DerivativeDownloadUrl</code> from a plain JavaScript object, optionally creating a new instance.
+   * Copies all relevant properties from <code>data</code> to <code>obj</code> if supplied or a new instance if not.
+   * @param {Object} data The plain JavaScript object bearing properties of interest.
+   * @param {module:model/DerivativeDownloadUrl} obj Optional instance to populate.
+   * @return {module:model/DerivativeDownloadUrl} The populated <code>DerivativeDownloadUrl</code> instance.
+   */
+  var constructFromObject = function (data, obj) {
+    if (data) {
+      obj = obj || new exports();
+
+      if (data.hasOwnProperty('etag')) {
+        obj.etag = ApiClient.convertToType(data.etag, 'String');
+      }
+      if (data.hasOwnProperty('size')) {
+        obj.size = ApiClient.convertToType(data.size, 'Integer');
+      }
+      if (data.hasOwnProperty('url')) {
+        obj.url = ApiClient.convertToType(data.url, 'String');
+      }
+      if (data.hasOwnProperty('content-type')) {
+        obj.contentType = ApiClient.convertToType(data.contentType, 'String');
+      }
+      if (data.hasOwnProperty('expiration')) {
+        obj.expiration = ApiClient.convertToType(data.expiration, 'Integer');
+      }
+    }
+    return obj;
+  };
+
+  /**
+   * Constructs a new <code>DerivativeDownloadUrl</code>.
+   * @alias module:model/DerivativeDownloadUrl
+   * @class
+   * @param etag {String} The calculated ETag hash of the derivative/file.
+   * @param size {Integer} The size of the derivative/file, in bytes.
+   * @param url {String} The download URL.
+   * @param contentType {String} The content type of the derivative/file.
+   * @param expiration {Integer} The 13-digit epoch time stamp indicating when the signed cookies expire.
+   * @param {Object} theData The plain JavaScript object bearing properties of interest.
+   * @param {module:model/DerivativeDownloadUrl} obj Optional instance to populate.
+   */
+  var exports = function (etag, size, url, contentType, expiration, theData, obj) {
+    var _this = this;
+
+    _this.etag = etag;
+    _this.size = size;
+    _this.url = url;
+    _this.contentType = contentType;
+    _this.expiration = expiration;
+
+    return constructFromObject(theData, obj || _this);
+  };
+
+  /**
+   * Constructs a <code>DerivativeDownloadUrl</code> from a plain JavaScript object, optionally creating a new instance.
+   * Copies all relevant properties from <code>data</code> to <code>obj</code> if supplied or a new instance if not.
+   * @param {Object} data The plain JavaScript object bearing properties of interest.
+   * @param {module:model/DerivativeDownloadUrl} obj Optional instance to populate.
+   * @return {module:model/DerivativeDownloadUrl} The populated <code>DerivativeDownloadUrl</code> instance.
+   */
+  exports.constructFromObject = constructFromObject;
+
+  /**
+   * The calculated ETag hash of the derivative/file, if available.
+   * @member {String} etag
+   */
+  exports.prototype.etag = undefined;
+  /**
+   * The size of the derivative/file, in bytes.
+   * @member {Integer} size
+   */
+  exports.prototype.size = undefined;
+  /**
+   * The download URL.
+   * @member {String} url
+   */
+  exports.prototype.url = undefined;
+  /**
+   * The content type of the derivative/file.
+   * @member {String} contentType
+   */
+  exports.prototype.contentType = undefined;
+  /**
+   * The 13-digit epoch time stamp indicating when the signed cookies expire.
+   * @member {Integer} expiration
+   */
+  exports.prototype.expiration = undefined;
+
+
+  return exports;
+}());

--- a/test/api/DerivativesApi.spec.js
+++ b/test/api/DerivativesApi.spec.js
@@ -307,6 +307,36 @@ module.export = (function () {
 			});
 		});
 
+		describe('getDerivativeDownloadUrl', function () {
+			it('should call getDerivativeDownloadUrl successfully', function (done) {
+				var opts = {};
+				var postBody = null;
+
+				var pathParams = {
+					'urn': sampleStrParam,
+					'derivativeUrn': sampleStrParam
+				};
+				var queryParams = {};
+				var headerParams = {};
+				var formParams = {};
+
+				var contentTypes = [];
+				var accepts = [];
+				var returnType = null;
+
+				mockedApiClientRequest.withArgs('/modelderivative/v2/designdata/{urn}/manifest/{derivativeUrn}/signedcookies', 'GET',
+					pathParams, queryParams, headerParams, formParams, postBody,
+					contentTypes, accepts, returnType, oauth2client, credentials).returns(Promise.resolve('Success result'));
+
+				instance.getDerivativeDownloadUrl(sampleStrParam, sampleStrParam, opts, oauth2client, credentials).then(function (response) {
+					expect(response).to.be.ok();
+					done();
+				}, function (err) {
+					done(err);
+				});
+			});
+		});
+
 		describe('getMetadata', function () {
 			it('should call getMetadata successfully', function (done) {
 				var opts = {};

--- a/test/api/DerivativesApi.spec.js
+++ b/test/api/DerivativesApi.spec.js
@@ -40,6 +40,7 @@ module.export = (function () {
 	var Manifest = require('../../src/model/Manifest');
 	var Metadata = require('../../src/model/Metadata');
 	var Result = require('../../src/model/Result');
+	var DerivativeDownloadUrl = require('../../src/model/DerivativeDownloadUrl');
 
 	var sampleStrParam = 'test_string';
 	var sampleIntParam = 10;
@@ -316,13 +317,16 @@ module.export = (function () {
 					'urn': sampleStrParam,
 					'derivativeUrn': sampleStrParam
 				};
-				var queryParams = {};
+				var queryParams = {
+					'minutes-expiration': opts.minutesExpiration,
+					'response-content-disposition': opts.responseContentDisposition
+				};
 				var headerParams = {};
 				var formParams = {};
 
-				var contentTypes = [];
-				var accepts = [];
-				var returnType = null;
+				var contentTypes = ['application/json'];
+				var accepts = ['*/*'];
+				var returnType = DerivativeDownloadUrl;
 
 				mockedApiClientRequest.withArgs('/modelderivative/v2/designdata/{urn}/manifest/{derivativeUrn}/signedcookies', 'GET',
 					pathParams, queryParams, headerParams, formParams, postBody,


### PR DESCRIPTION
Add support for [Fetch Derivative Download URL](https://aps.autodesk.com/en/docs/model-derivative/v2/reference/http/urn-manifest-derivativeUrn-signedcookies-GET/).
Add a test and update the ReadMe.
Sort the *ForgeSdk.DerivativesApi* by order of appearance in the DerivativeApi.js.