### PR TITLE
Fix getDerivativeManifest to get Buffer instead binary string

### DIFF
--- a/src/api/DerivativesApi.js
+++ b/src/api/DerivativesApi.js
@@ -318,11 +318,12 @@ module.exports = (function () {
 			var contentTypes = ['application/json'];
 			var accepts = ['application/octet-stream'];
 			var returnType = null;
+			var responseType = 'arraybuffer';
 
 			return this.apiClient.callApi(
 				this.regionPaths[this.region] + '/designdata/{urn}/manifest/{derivativeUrn}', 'GET',
 				pathParams, queryParams, headerParams, formParams, postBody,
-				contentTypes, accepts, returnType, oauth2client, credentials
+				contentTypes, accepts, returnType, oauth2client, credentials, responseType
 			);
 		};
 


### PR DESCRIPTION
This commit is to fix a issue in a function of DerivativesAPI. 
The details are specified here: [Issue](https://github.com/Autodesk-Forge/forge-api-nodejs-client/issues/117)